### PR TITLE
Parallel test execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 schema-salad >= 1.14
 typing >= 3.5.2
+futures >= 3.0.5; python_version == '2.7'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,13 @@ setup(name='cwltest',
       packages=["cwltest"],
       install_requires=[
           'schema-salad >= 1.14',
-          'typing >= 3.5.2' ],
+          'typing >= 3.5.2'
+      ],
+      extras_require={
+          ':python_version == "2.7"': [
+              'futures >= 3.0.5',
+          ],
+      },
       tests_require=[],
       entry_points={
           'console_scripts': [ "cwltest=cwltest:main" ]


### PR DESCRIPTION
New "jobs" (-j) argument for specifying the number of threads to use
when running tests.

`concurrent.futures.ThreadPoolExecutor` is used for parallel test execution, the added "futures" dependency backports this feature to Python 2.7.

If a `-j` command line argument is not specified (or is set to one), the cwltest commands behaves as it did before these changes -- with the exception that Ctrl+C needs to be pressed two times to interrupt test execution (because test execution is offloaded to separate threads).