### PR TITLE
Use sys.stderr.isatty() to tweak output behavior

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -154,6 +154,12 @@ def run_test(args, i, tests):  # type: (argparse.Namespace, int, List[Dict[str, 
     outdir = outstr = outerr = test_command = None
     duration = 0.0
     t = tests[i]
+    prefix = ""
+    suffix = ""
+    if sys.stderr.isatty():
+        prefix = "\r"
+    else:
+        suffix = "\n"
     try:
         test_command = [args.tool]
         test_command.extend(args.args)
@@ -169,7 +175,7 @@ def run_test(args, i, tests):  # type: (argparse.Namespace, int, List[Dict[str, 
         if t.get("job"):
             test_command.append(t["job"])
 
-        sys.stderr.write("\rTest [%i/%i] " % (i + 1, len(tests)))
+        sys.stderr.write("%sTest [%i/%i] %s" % (prefix, i + 1, len(tests), suffix))
         sys.stderr.flush()
 
         start_time = time.time()


### PR DESCRIPTION
Depending on whether it is printing to a terminal or not.