### PR TITLE
Add known failure testing capability

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -220,6 +220,8 @@ def run_test(args, i, tests):  # type: (argparse.Namespace, int, List[Dict[str, 
     except subprocess.CalledProcessError as err:
         if err.returncode == UNSUPPORTED_FEATURE:
             return TestResult(UNSUPPORTED_FEATURE, outstr, outerr, duration, args.classname)
+        elif t.get("should_fail", False):
+            return TestResult(0, outstr, outerr, duration, args.classname)
         else:
             _logger.error(u"""Test failed: %s""", " ".join([pipes.quote(tc) for tc in test_command]))
             _logger.error(t.get("doc"))
@@ -236,6 +238,12 @@ def run_test(args, i, tests):  # type: (argparse.Namespace, int, List[Dict[str, 
         raise
 
     fail_message = ''
+
+    if t.get("should_fail", False):
+        _logger.warn(u"""Test failed: %s""", " ".join([pipes.quote(tc) for tc in test_command]))
+        _logger.warn(t.get("doc"))
+        _logger.warn(u"Returned zero but it should be non-zero")
+        return TestResult(1, outstr, outerr, duration, args.classname)
 
     try:
         compare(t.get("output"), out)


### PR DESCRIPTION
This request is to solve #37 by adding known failure capability to `cwltest`.

To use this feature, just add `should_fail: true` to tests in which the execution should fail.
This field is optional. When you do not specify `should_fail` field, `cwltest` treats that `should_fail` is false.
For example:
```yml
- doc: Test for section 11 (1st example)
  job: 11-records/record-job1.yml
  tool: 11-records/record.cwl
  should_fail: true
```

When `should_fail` is false, `cwltest` behaves as same as before. That is, it passes a test when the execution succeeds and it fails a test when the execution fails.
When `should_fail` is true, `cwltest` fails a test when the execution succeeds.
Here is an example message for it (I added `#` comments for explanation):
```
Test failed: cwl-runner --outdir=/var/folders/gk/zyzswjbs6m59ywz69zhrtmlh0000gn/T/tmp7dsw3jn4 --quiet 04-output/tar.cwl 04-output/tar-job.yml
Test for section 4 # corresponding `doc` field in YAML file
Returned zero but it should be non-zero # error message
```

Note: we may need other fields for more precise checking or there may be a better field name than `should_fail`.
