### PR TITLE
Handling directory paths

### DIFF
--- a/cwltest/utils.py
+++ b/cwltest/utils.py
@@ -29,7 +29,7 @@ def compare_location(expected, actual):
         return
     if actual.get("class") == "Directory":
         actual[comp] = actual[comp].rstrip("/")
-    
+
     if expected[comp] != "Any" and (not (actual[comp].endswith("/" + expected[comp]) or
                                     ("/" not in actual[comp] and expected[comp] == actual[comp]))):
         raise CompareFail.format(expected, actual, u"%s does not end with %s" % (actual[comp], expected[comp]))

--- a/cwltest/utils.py
+++ b/cwltest/utils.py
@@ -27,6 +27,9 @@ def compare_location(expected, actual):
         comp = "location"
     else:
         return
+    if actual.get("class") == "Directory":
+      actual[comp] = actual[comp].rstrip("/")
+    
     if expected[comp] != "Any" and (not (actual[comp].endswith("/" + expected[comp]) or
                                     ("/" not in actual[comp] and expected[comp] == actual[comp]))):
         raise CompareFail.format(expected, actual, u"%s does not end with %s" % (actual[comp], expected[comp]))

--- a/cwltest/utils.py
+++ b/cwltest/utils.py
@@ -28,7 +28,7 @@ def compare_location(expected, actual):
     else:
         return
     if actual.get("class") == "Directory":
-      actual[comp] = actual[comp].rstrip("/")
+        actual[comp] = actual[comp].rstrip("/")
     
     if expected[comp] != "Any" and (not (actual[comp].endswith("/" + expected[comp]) or
                                     ("/" not in actual[comp] and expected[comp] == actual[comp]))):


### PR DESCRIPTION
Strips the trailing slash from directory result's location to match the way unix treats paths

https://github.com/common-workflow-language/common-workflow-language/issues/619

[rfc3986](https://tools.ietf.org/html/rfc3986#section-3.3)