### PR TITLE
Fix a crash when --verbose was used

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -97,7 +97,7 @@ def run_test(args, i, tests, timeout):
         start_time = time.time()
         stderr = subprocess.PIPE if not args.verbose else None
         process = subprocess.Popen(test_command, stdout=subprocess.PIPE, stderr=stderr)
-        outstr, outerr = [var.decode('utf-8') for var in process.communicate(timeout=timeout)]
+        outstr, outerr = [(var or b'').decode('utf-8') for var in process.communicate(timeout=timeout)]
         return_code = process.poll()
         duration = time.time() - start_time
         if return_code:


### PR DESCRIPTION
When the `--verbose` option is set, I get a crash like this at the very end of the run:

```
--- Running conformance test v1.0 on /Users/joel/cwltest/venv/bin/cwl-runner ---
/Users/joel/cwltest/venv/bin/cwl-runner 1.0.20180508202931
cwltest --tool /Users/joel/cwltest/venv/bin/cwl-runner --test=conformance_test_v1.0.yaml -n9 --verbose --basedir /Users/joel/cwltest/common-workflow-language/v1.0 --
Test [9/128] Test command execution in Docker with stdout redirection
Traceback (most recent call last):
  File "/Users/joel/cwltest/venv/bin/cwltest", line 11, in <module>
    load_entry_point('cwltest==1.0.20180503153209', 'console_scripts', 'cwltest')()
  File "/Users/joel/cwltest/venv/lib/python2.7/site-packages/cwltest/__init__.py", line 270, in main
    test_result = job.result()
  File "/Users/joel/cwltest/venv/lib/python2.7/site-packages/futures-3.2.0-py2.7.egg/concurrent/futures/_base.py", line 462, in result
    return self.__get_result()
  File "/Users/joel/cwltest/venv/lib/python2.7/site-packages/futures-3.2.0-py2.7.egg/concurrent/futures/thread.py", line 63, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/joel/cwltest/venv/lib/python2.7/site-packages/cwltest/__init__.py", line 100, in run_test
    outstr, outerr = [var.decode('utf-8') for var in process.communicate(timeout=timeout)]
AttributeError: 'NoneType' object has no attribute 'decode'
```

This is caused because `communicate` returns a tuple `(stdout, stderr)` only when both stdout and stderr are `PIPE`d. When stderr is passed through, as with `--verbose`, it returns `(stdout, None)`.