### PR TITLE
Improve checking for cwltool in macOS

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -61,7 +61,7 @@ def prepare_test_command(tool,      # type: str
 
     # Add prefixes if running on MacOSX so that boot2docker writes to /Users
     with templock:
-        if 'darwin' in sys.platform and tool == 'cwltool':
+        if 'darwin' in sys.platform and tool.endswith('cwltool'):
             outdir = tempfile.mkdtemp(prefix=os.path.abspath(os.path.curdir))
             test_command.extend(["--tmp-outdir-prefix={}".format(outdir),
                                  "--tmpdir-prefix={}".format(outdir)])


### PR DESCRIPTION
In macOS environment, directory names for the temporary files are located in different from Linux systems (e.g., `/private/var` and `/var`).

This request improves the way to check whether the runner is `cwltool` by using `endswith` instead of simple `==` checking.
