### PR TITLE
Add --badgedir option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,3 +26,26 @@ Run on the command line
 Simple command::
 
   cwltest --test test-descriptions.yml --tool cwl-runner
+
+Generate conformance badges using cwltest
+-----------------------------------------
+
+To make badges that show the results of the conformance test,
+you can generate JSON files for https://badgen.net by using --badgedir option
+
+To generate JSON files::
+
+  cwltest --test test-descriptions.yml --tool cwl-runner --badgedir badges
+  ...
+  $ cat badges/command_line_tool.json | jq .
+  {
+    "subject": "[CWL] command_line_tool",
+    "status": "100%",
+    "color": "green"
+  }
+
+Once you upload JSON file to a server, you make a badge by using a link like https://flat.badgen.net/https/path/to/generated/json.
+
+Here is an example of markdown to add a badge::
+
+  ![test result](https://flat.badgen.net/https/path/to/generated/json)


### PR DESCRIPTION
This request is to prepare to generate badge for the conformance test.
It adds `--badgedir` option that specifies a directory name for the JSON files for the badges.

When `--badgedir` is specified, `cwltest` makes a directory and generates JSON files for each tag in the conformance test.

Here is a running example:
```console:
$ cwltest --tool cwltool --test=conformance_test_v1.0.yaml -n 1-3 --basedir v1.0 --badgedir=badges
Test [1/197] General test of command line generation
Test [2/197] Test nested prefixes with arrays
Test [3/197] Test nested command line bindings
All tests passed
$ ls badges
command_line_tool.json  required.json  schema_def.json
$ cat badges/command_line_tool.json | jq .
{
  "subject": "[CWL] command_line_tool",
  "status": "100%",
  "color": "green"
}
```

By using this JSON files, we can generate nice badges for each tag (i.e., for command line tool, for workflow, and for each requirement).

For example, when we upload the generated file ([here](https://raw.githubusercontent.com/tom-tan/badge-test/master/command_line_tool.json) is a link to the file),
```
$ curl -XGET https://raw.githubusercontent.com/tom-tan/badge-test/master/command_line_tool.json
{"subject": "[CWL] command_line_tool", "status": "100%", "color": "green"}
```
we can generate the following badge by using https://badgen.net:

![command_line_tool](https://flat.badgen.net/https/raw.githubusercontent.com/tom-tan/badge-test/master/command_line_tool.json)
