### PR TITLE
Replace `assertEquals` with `assertEqual`

### DIFF
--- a/cwltest/tests/test_categories.py
+++ b/cwltest/tests/test_categories.py
@@ -12,8 +12,8 @@ class TestCategories(unittest.TestCase):
     def test_unsupported_with_required_tests(self):
         args = ["--test", get_data("tests/test-data/required-unsupported.yml")]
         error_code, stdout, stderr = run_with_mock_cwl_runner(args)
-        self.assertEquals(error_code, 1)
-        self.assertEquals(
+        self.assertEqual(error_code, 1)
+        self.assertEqual(
             "Test [1/2] Required test that is unsupported (without tags){n}{n}"
             "Test [2/2] Required test that is unsupported (with tags){n}{n}"
             "0 tests passed, 2 failures, 0 unsupported "
@@ -22,15 +22,15 @@ class TestCategories(unittest.TestCase):
     def test_unsupported_with_optional_tests(self):
         args = ["--test", get_data("tests/test-data/optional-unsupported.yml")]
         error_code, stdout, stderr = run_with_mock_cwl_runner(args)
-        self.assertEquals(error_code, 0)
-        self.assertEquals("Test [1/1] Optional test that is unsupported{n}{n}"
-                          "0 tests passed, 1 unsupported "
-                          "features{n}".format(n=n), stderr)
+        self.assertEqual(error_code, 0)
+        self.assertEqual("Test [1/1] Optional test that is unsupported{n}{n}"
+                         "0 tests passed, 1 unsupported "
+                         "features{n}".format(n=n), stderr)
 
     def test_error_with_optional_tests(self):
         args = ["--test", get_data("tests/test-data/optional-error.yml")]
         error_code, stdout, stderr = run_with_mock_cwl_runner(args)
-        self.assertEquals(error_code, 1)
+        self.assertEqual(error_code, 1)
         self.assertIn("1 failures", stderr)
 
     def test_category_in_junit_xml(self):
@@ -40,5 +40,5 @@ class TestCategories(unittest.TestCase):
         tree = ET.parse(junit_xml_report)
         root = tree.getroot()
         category = root.find("testsuite").find("testcase").attrib['class']
-        self.assertEquals(category, "js, init_work_dir")
+        self.assertEqual(category, "js, init_work_dir")
         os.remove(junit_xml_report)

--- a/cwltest/tests/test_short_names.py
+++ b/cwltest/tests/test_short_names.py
@@ -25,9 +25,9 @@ class TestShortNames(unittest.TestCase):
     def test_list_tests(self):
         args = ["--test", get_data("tests/test-data/with-and-without-short-names.yml"), "-l"]
         error_code, stdout, stderr = run_with_mock_cwl_runner(args)
-        self.assertEquals("[1] Test without a short name{n}"
-                          "[2] opt-error: Test with a short name{n}".format(n=n),
-                          stdout)
+        self.assertEqual("[1] Test without a short name{n}"
+                         "[2] opt-error: Test with a short name{n}".format(n=n),
+                         stdout)
 
     def test_short_name_in_junit_xml(self):
         junit_xml_report = get_data("tests/test-data/junit-report.xml")
@@ -36,5 +36,5 @@ class TestShortNames(unittest.TestCase):
         tree = ET.parse(junit_xml_report)
         root = tree.getroot()
         category = root.find("testsuite").find("testcase").attrib['file']
-        self.assertEquals(category, "opt-error")
+        self.assertEqual(category, "opt-error")
         os.remove(junit_xml_report)


### PR DESCRIPTION
This request just replaces `assertEquals` with `assertEqual` to remove the following warning messages when testing:
```
================================= warnings summary ==================================
cwltest/tests/test_categories.py::TestCategories::test_category_in_junit_xml
  /Users/tanjo/repos/cwltest/cwltest/tests/test_categories.py:43: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(category, "js, init_work_dir")

cwltest/tests/test_categories.py::TestCategories::test_error_with_optional_tests
  /Users/tanjo/repos/cwltest/cwltest/tests/test_categories.py:33: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(error_code, 1)

cwltest/tests/test_categories.py::TestCategories::test_unsupported_with_optional_tests
  /Users/tanjo/repos/cwltest/cwltest/tests/test_categories.py:25: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(error_code, 0)
  /Users/tanjo/repos/cwltest/cwltest/tests/test_categories.py:28: DeprecationWarning: Please use assertEqual instead.
    "features{n}".format(n=n), stderr)

cwltest/tests/test_categories.py::TestCategories::test_unsupported_with_required_tests
  /Users/tanjo/repos/cwltest/cwltest/tests/test_categories.py:15: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(error_code, 1)
  /Users/tanjo/repos/cwltest/cwltest/tests/test_categories.py:20: DeprecationWarning: Please use assertEqual instead.
    "features{n}".format(n=n), stderr)

cwltest/tests/test_short_names.py::TestShortNames::test_list_tests
  /Users/tanjo/repos/cwltest/cwltest/tests/test_short_names.py:30: DeprecationWarning: Please use assertEqual instead.
    stdout)

cwltest/tests/test_short_names.py::TestShortNames::test_short_name_in_junit_xml
  /Users/tanjo/repos/cwltest/cwltest/tests/test_short_names.py:39: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(category, "opt-error")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================= 13 passed, 8 warnings in 8.09 seconds =======================
```