### PR TITLE
Generate yellow badges for the results of non-required tests

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -475,8 +475,10 @@ def main():  # type: () -> int
             percent = int((npassed[t] / float(v)) * 100)
             if npassed[t] == v:
                 color = "green"
-            else:
+            elif t == "required":
                 color = "red"
+            else:
+                color = "yellow"
 
             with open("{}/{}.json".format(args.badgedir, t), "w") as out:
                 out.write(


### PR DESCRIPTION
This request generates yellow badges instead of red badges for non-100% results of non-`required` tags.

Currently `cwltest --badgedir` generates only green and red badges (e.g., ![](https://badgen.net/badge/inline_javascript/100%25/green?icon=commonwl) and ![](https://badgen.net/badge/docker/60%25/red?icon=commonwl)).

It would be nice if it generates:
- green badges for the tags with 100% passed (![](https://badgen.net/badge/inline_javascript/100%25/green?icon=commonwl)),
- red badges for the `required` tag and not 100% passed (![](https://badgen.net/badge/required/89%25/red?icon=commonwl)), and
- yellow badges for the tags except `required` and not 100% passed (![](https://badgen.net/badge/docker/80%25/yellow?icon=commonwl)).

It makes easier for users to distinguish the failures of required features from the failures of optional features.

Note: By merging this request, it may generate yellow badges rather than red badges for `command_line_tool`, `expression_tool` and `workflow`. IMO it is acceptable because they include the results of tests for both of required and optional features.