### PR TITLE
Update the badge section in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,13 +48,13 @@ To generate JSON files::
   ...
   $ cat badges/command_line_tool.json | jq .
   {
-    "subject": "[CWL] command_line_tool",
+    "subject": "command_line_tool",
     "status": "100%",
     "color": "green"
   }
 
-Once you upload JSON file to a server, you make a badge by using a link like https://flat.badgen.net/https/path/to/generated/json.
+Once you upload JSON file to a server, you make a badge by using a link like https://badgen.net/https/path/to/generated/json or https://flat.badgen.net/https/path/to/generated/json (for flat badges).
 
 Here is an example of markdown to add a badge::
 
-  ![test result](https://flat.badgen.net/https/path/to/generated/json)
+  ![test result](https://flat.badgen.net/https/path/to/generated/json?icon=commonwl)


### PR DESCRIPTION
This request follows the update in #100 including the icon of commonwl such as ![with-icon](https://badgen.net/badge/with/icon/green?icon=commonwl).

It also adds a description of the non-flat badge ![non-flat](https://badgen.net/badge/non-flat/badge/green) in addition to the flat badge ![flat](https://flat.badgen.net/badge/flat/badge/green).
