### PR TITLE
Print `doc` field in one line

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -127,7 +127,7 @@ def run_test(
                     test_number,
                     total_tests,
                     test.get("short_name"),
-                    test.get("doc", "").replace("\n", " "),
+                    test.get("doc", "").replace("\n", " ").strip(),
                     suffix,
                 )
             )
@@ -138,7 +138,7 @@ def run_test(
                     prefix,
                     test_number,
                     total_tests,
-                    test.get("doc", "").replace("\n", " "),
+                    test.get("doc", "").replace("\n", " ").strip(),
                     suffix,
                 )
             )
@@ -180,7 +180,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.error(test.get("doc", "").replace("\n", " "))
+        _logger.error(test.get("doc", "").replace("\n", " ").strip())
         if err.returncode == UNSUPPORTED_FEATURE:
             _logger.error("Does not support required feature")
         else:
@@ -209,7 +209,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.error(test.get("doc", "").replace("\n", " "))
+        _logger.error(test.get("doc", "").replace("\n", " ").strip())
         # Kill and re-communicate to get the logs and reap the child, as
         # instructed in the subprocess docs.
         if process:
@@ -235,7 +235,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.warning(test.get("doc", "").replace("\n", " "))
+        _logger.warning(test.get("doc", "").replace("\n", " ").strip())
         _logger.warning("Returned zero but it should be non-zero")
         return TestResult(1, outstr, outerr, duration, args.classname)
 
@@ -247,7 +247,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.warning(test.get("doc", "").replace("\n", " "))
+        _logger.warning(test.get("doc", "").replace("\n", " ").strip())
         _logger.warning("Compare failure %s", ex)
         fail_message = str(ex)
 

--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -127,14 +127,14 @@ def run_test(
                     test_number,
                     total_tests,
                     test.get("short_name"),
-                    test.get("doc"),
+                    test.get("doc").replace("\n", " "),
                     suffix,
                 )
             )
         else:
             sys.stderr.write(
                 "%sTest [%i/%i] %s%s\n"
-                % (prefix, test_number, total_tests, test.get("doc"), suffix)
+                % (prefix, test_number, total_tests, test.get("doc").replace("\n", " "), suffix)
             )
         if verbose:
             sys.stderr.write(f"Running: {' '.join(test_command)}\n")
@@ -174,7 +174,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.error(test.get("doc"))
+        _logger.error(test.get("doc").replace("\n", " "))
         if err.returncode == UNSUPPORTED_FEATURE:
             _logger.error("Does not support required feature")
         else:
@@ -203,7 +203,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.error(test.get("doc"))
+        _logger.error(test.get("doc").replace("\n", " "))
         # Kill and re-communicate to get the logs and reap the child, as
         # instructed in the subprocess docs.
         if process:
@@ -229,7 +229,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.warning(test.get("doc"))
+        _logger.warning(test.get("doc").replace("\n", " "))
         _logger.warning("Returned zero but it should be non-zero")
         return TestResult(1, outstr, outerr, duration, args.classname)
 
@@ -241,7 +241,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.warning(test.get("doc"))
+        _logger.warning(test.get("doc").replace("\n", " "))
         _logger.warning("Compare failure %s", ex)
         fail_message = str(ex)
 
@@ -456,10 +456,10 @@ def main():  # type: () -> int
         for i, t in enumerate(tests):
             if t.get("short_name"):
                 print(
-                    "[%i] %s: %s" % (i + 1, t["short_name"], t.get("doc", "").strip())
+                    "[%i] %s: %s" % (i + 1, t["short_name"], t.get("doc", "").replace("\n", " ").strip())
                 )
             else:
-                print("[%i] %s" % (i + 1, t.get("doc", "").strip()))
+                print("[%i] %s" % (i + 1, t.get("doc", "").replace("\n", " ").strip()))
 
         return 0
 

--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -127,14 +127,20 @@ def run_test(
                     test_number,
                     total_tests,
                     test.get("short_name"),
-                    test.get("doc").replace("\n", " "),
+                    test.get("doc", "").replace("\n", " "),
                     suffix,
                 )
             )
         else:
             sys.stderr.write(
                 "%sTest [%i/%i] %s%s\n"
-                % (prefix, test_number, total_tests, test.get("doc").replace("\n", " "), suffix)
+                % (
+                    prefix,
+                    test_number,
+                    total_tests,
+                    test.get("doc", "").replace("\n", " "),
+                    suffix,
+                )
             )
         if verbose:
             sys.stderr.write(f"Running: {' '.join(test_command)}\n")
@@ -174,7 +180,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.error(test.get("doc").replace("\n", " "))
+        _logger.error(test.get("doc", "").replace("\n", " "))
         if err.returncode == UNSUPPORTED_FEATURE:
             _logger.error("Does not support required feature")
         else:
@@ -203,7 +209,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.error(test.get("doc").replace("\n", " "))
+        _logger.error(test.get("doc", "").replace("\n", " "))
         # Kill and re-communicate to get the logs and reap the child, as
         # instructed in the subprocess docs.
         if process:
@@ -229,7 +235,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.warning(test.get("doc").replace("\n", " "))
+        _logger.warning(test.get("doc", "").replace("\n", " "))
         _logger.warning("Returned zero but it should be non-zero")
         return TestResult(1, outstr, outerr, duration, args.classname)
 
@@ -241,7 +247,7 @@ def run_test(
             test_number,
             " ".join([quote(tc) for tc in test_command]),
         )
-        _logger.warning(test.get("doc").replace("\n", " "))
+        _logger.warning(test.get("doc", "").replace("\n", " "))
         _logger.warning("Compare failure %s", ex)
         fail_message = str(ex)
 
@@ -456,7 +462,12 @@ def main():  # type: () -> int
         for i, t in enumerate(tests):
             if t.get("short_name"):
                 print(
-                    "[%i] %s: %s" % (i + 1, t["short_name"], t.get("doc", "").replace("\n", " ").strip())
+                    "[%i] %s: %s"
+                    % (
+                        i + 1,
+                        t["short_name"],
+                        t.get("doc", "").replace("\n", " ").strip(),
+                    )
                 )
             else:
                 print("[%i] %s" % (i + 1, t.get("doc", "").replace("\n", " ").strip()))

--- a/cwltest/tests/test-data/multi-lined-doc.yml
+++ b/cwltest/tests/test-data/multi-lined-doc.yml
@@ -1,0 +1,15 @@
+- job: v1.0/cat-job.json
+  output: {}
+  tool: return-0.cwl
+  doc: |
+    Test with
+    label
+  label: opt-error
+  tags: [ js, init_work_dir ]
+- job: v1.0/cat-job.json
+  output: {}
+  tool: return-0.cwl
+  doc: |
+    Test without
+    label
+  tags: [ js, init_work_dir ]

--- a/cwltest/tests/test_multi_lined_doc.py
+++ b/cwltest/tests/test_multi_lined_doc.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from .util import run_with_mock_cwl_runner, get_data
 import defusedxml.ElementTree as ET
 
+
 def test_run():
     args = ["--test", get_data("tests/test-data/multi-lined-doc.yml")]
     error_code, stdout, stderr = run_with_mock_cwl_runner(args)
     assert f"Test [1/2] opt-error: Test with label{n}" in stderr
     assert f"Test [2/2] Test without label{n}" in stderr
+
 
 def test_list():
     args = ["--test", get_data("tests/test-data/multi-lined-doc.yml"), "-l"]

--- a/cwltest/tests/test_multi_lined_doc.py
+++ b/cwltest/tests/test_multi_lined_doc.py
@@ -1,0 +1,18 @@
+import os
+from os import linesep as n
+from pathlib import Path
+
+from .util import run_with_mock_cwl_runner, get_data
+import defusedxml.ElementTree as ET
+
+def test_run():
+    args = ["--test", get_data("tests/test-data/multi-lined-doc.yml")]
+    error_code, stdout, stderr = run_with_mock_cwl_runner(args)
+    assert f"Test [1/2] opt-error: Test with label{n}" in stderr
+    assert f"Test [2/2] Test without label{n}" in stderr
+
+def test_list():
+    args = ["--test", get_data("tests/test-data/multi-lined-doc.yml"), "-l"]
+    error_code, stdout, stderr = run_with_mock_cwl_runner(args)
+    assert f"[1] opt-error: Test with label{n}" in stdout
+    assert f"[2] Test without label{n}" in stdout


### PR DESCRIPTION
It just replaces all `"\n"` with " " when `cwltest` prints the `doc` field to the log as well as it lists the all tests with `-l`.
It makes the output grep-able.

- Before merging this request (See the line `Test [347/348]`):
```console
$ ./run_test.sh EXTRA="--no-container" -n=345-348
--- Running CWL Conformance Tests v1.2 on /home/vscode/.local/bin/cwl-runner ---
/home/vscode/.local/bin/cwl-runner 3.1.20220502060230
URI prefix 'tests/colon' of 'tests/colon:test:job.yaml' not recognized, are you missing a $namespaces section?
URI prefix 'tests/colon' of 'tests/colon:test.cwl' not recognized, are you missing a $namespaces section?
Test [345/348] record_outputeval: Use of outputEval on a record itself, not the fields of the record
Test [346/348] record_outputeval_nojs: Use of outputEval on a record itself, not the fields of the record (without javascript)
Test [347/348] staging-basename: Use of expression tool to change basename of file, then correctly staging
the file using the new name.

Test [348/348] runtime-outdir: Use of $(runtime.outdir) for outputBinding glob.

All tests passed

All tool tests succeeded
```

- After merging this request:
```console
$ ./run_test.sh EXTRA="--no-container" -n=345-348
--- Running CWL Conformance Tests v1.2 on /home/vscode/.local/bin/cwl-runner ---
/home/vscode/.local/bin/cwl-runner 3.1.20220502060230
URI prefix 'tests/colon' of 'tests/colon:test.cwl' not recognized, are you missing a $namespaces section?
URI prefix 'tests/colon' of 'tests/colon:test:job.yaml' not recognized, are you missing a $namespaces section?
Test [345/348] record_outputeval: Use of outputEval on a record itself, not the fields of the record
Test [346/348] record_outputeval_nojs: Use of outputEval on a record itself, not the fields of the record (without javascript)
Test [347/348] staging-basename: Use of expression tool to change basename of file, then correctly staging the file using the new name. 
Test [348/348] runtime-outdir: Use of $(runtime.outdir) for outputBinding glob. 
All tests passed

All tool tests succeeded
```
