### PR TITLE
Support string `id` field

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess  # nosec
 import sys
@@ -39,6 +40,16 @@ UNSUPPORTED_FEATURE = 33
 DEFAULT_TIMEOUT = 600  # 10 minutes
 
 templock = threading.Lock()
+
+
+def shortname(
+    name,  # type: str
+):  # type: (...) -> str
+    """
+    Return the short name of a given name.
+    It is a workaround of https://github.com/common-workflow-language/schema_salad/issues/511.
+    """
+    return [n for n in re.split("[/#]", name) if len(n)][-1]
 
 
 def prepare_test_command(
@@ -448,6 +459,8 @@ def main():  # type: () -> int
     for t in tests:
         if t.get("label"):
             t["short_name"] = t["label"]
+        elif t.get("id") and isinstance(t.get("id"), str):
+            t["short_name"] = shortname(t["id"])
 
     if args.show_tags:
         alltags = set()  # type: Set[str]

--- a/cwltest/tests/test-data/string-id.yml
+++ b/cwltest/tests/test-data/string-id.yml
@@ -1,0 +1,5 @@
+- job: v1.0/cat1-job.json
+  output: {}
+  tool: return-0.cwl
+  doc: Test with a string label
+  id: test-string-id

--- a/cwltest/tests/test_string_id.py
+++ b/cwltest/tests/test_string_id.py
@@ -1,0 +1,12 @@
+import os
+from os import linesep as n
+from pathlib import Path
+
+from .util import run_with_mock_cwl_runner, get_data
+import defusedxml.ElementTree as ET
+
+
+def test_list():
+    args = ["--test", get_data("tests/test-data/string-id.yml"), "-l"]
+    error_code, stdout, stderr = run_with_mock_cwl_runner(args)
+    assert f"[1] test-string-id: Test with a string label{n}" in stdout


### PR DESCRIPTION
It partially solves #110 by supporting `id` field with string value.

Currently `cwltest` copies `label` field to `short_name` field and print it for each test.
This request decides `short_name` as follows:
- use `label` field if available
- use `id` field if it has a string value
- otherwise `cwltest` does not set `short_name` as same as before this request

---
- Before merging this request (See [tests/conditionals/test-index.yaml#L419 in cwl-v1.2](https://github.com/common-workflow-language/cwl-v1.2/blob/033ed18427380cf532fdd3c0bc5d4b24b2f7e945/tests/conditionals/test-index.yaml#L419)):
```console
$ ./run_test.sh -l
...
[306] Default inputs, choose step to run based on what was provided, first case
[307] Default inputs, choose step to run based on what was provided, second case
...
```

- After merging this request:
```console
$ ./run_test.sh -l
...
[306] cond-with-defaults-1: Default inputs, choose step to run based on what was provided, first case
[307] cond-with-defaults-2: Default inputs, choose step to run based on what was provided, second case
...
```
