### PR TITLE
Add strict schema

### DIFF
--- a/cwltest/cwltest-schema-strict.yml
+++ b/cwltest/cwltest-schema-strict.yml
@@ -5,7 +5,7 @@ $graph:
     documentRoot: true
     fields:
       id:
-        type: int
+        type: string
         jsonldPredicate:
           _type: "@id"
           identity: true

--- a/cwltest/cwltest-schema-strict.yml
+++ b/cwltest/cwltest-schema-strict.yml
@@ -1,0 +1,27 @@
+$base: "https://w3id.org/cwl/cwltest#"
+$graph:
+  - name: TestCase
+    type: record
+    documentRoot: true
+    fields:
+      id:
+        type: int
+        jsonldPredicate:
+          _type: "@id"
+          identity: true
+      short_name: string?
+      doc: string?
+      tags: string[]
+      tool:
+        type: string
+        jsonldPredicate:
+          _type: "@id"
+      job:
+        type: string?
+        jsonldPredicate:
+          _type: "@id"
+      should_fail:
+        type: boolean?
+        default: false
+      output:
+        type: Any?


### PR DESCRIPTION
This request introduces a strict schema for cwltest as a preparation of #110.
Here is a difference of [cwltest-schema](https://github.com/common-workflow-language/cwltest/blob/main/cwltest/cwltest-schema.yml) and strict schema.
- `id` field is limited to `string`,
- `label` field is removed, and
- `tags` field is mandatory

It enable us to migrate to a new schema and enable us not to introduce a regression that uses current schema with integer `id` field.
Note that it is not to enforce a new schema because it breaks existing systems that depend on the current schema of cwltest.

It is also important to add deprecation and migration messages in cwltest but it is out of scope of this request.

