### PR TITLE
Add `--exclude-tags` option

### DIFF
--- a/cwltest/__init__.py
+++ b/cwltest/__init__.py
@@ -317,6 +317,9 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
         "--only-tools", action="store_true", help="Only test CommandLineTools"
     )
     parser.add_argument("--tags", type=str, default=None, help="Tags to be tested")
+    parser.add_argument(
+        "--exclude-tags", type=str, default=None, help="Tags not to be tested"
+    )
     parser.add_argument("--show-tags", action="store_true", help="Show all Tags.")
     parser.add_argument(
         "--junit-xml", type=str, default=None, help="Path to JUnit xml file"
@@ -455,6 +458,15 @@ def main():  # type: () -> int
             ts = t.get("tags", [])
             if any(tag in ts for tag in tags):
                 tests.append(t)
+
+    if args.exclude_tags:
+        ex_tests = []
+        tags = args.exclude_tags.split(",")
+        for t in tests:
+            ts = t.get("tags", [])
+            if all(tag not in ts for tag in tags):
+                ex_tests.append(t)
+        tests = ex_tests
 
     for t in tests:
         if t.get("label"):

--- a/cwltest/tests/test-data/exclude-tags.yml
+++ b/cwltest/tests/test-data/exclude-tags.yml
@@ -1,0 +1,24 @@
+- job: v1.0/cat-job.json
+  output: {}
+  tool: return-0.cwl
+  doc: |
+    Test with
+    label
+  id: opt-error1
+  tags: [ command_line_tool ]
+- job: v1.0/cat-job.json
+  id: opt-error2
+  output: {}
+  tool: return-0.cwl
+  doc: |
+    Test without
+    label
+  tags: [ command_line_tool, workflow ]
+- job: v1.0/cat-job.json
+  id: opt-error3
+  output: {}
+  tool: return-0.cwl
+  doc: |
+    Test without
+    label
+  tags: [ workflow ]

--- a/cwltest/tests/test_exclude_tags.py
+++ b/cwltest/tests/test_exclude_tags.py
@@ -1,0 +1,33 @@
+import os
+from os import linesep as n
+from pathlib import Path
+
+from .util import run_with_mock_cwl_runner, get_data
+import defusedxml.ElementTree as ET
+
+
+def test_list_only_exclude():
+    args = [
+        "--test",
+        get_data("tests/test-data/exclude-tags.yml"),
+        "-l",
+        "--exclude-tags=workflow",
+    ]
+    error_code, stdout, stderr = run_with_mock_cwl_runner(args)
+    assert f"[1] opt-error1: Test with label{n}" in stdout
+    assert "opt-error2" not in stdout
+    assert "opt-error3" not in stdout
+
+
+def test_list_include_and_exclude():
+    args = [
+        "--test",
+        get_data("tests/test-data/exclude-tags.yml"),
+        "-l",
+        "--tags=command_line_tool",
+        "--exclude-tags=workflow",
+    ]
+    error_code, stdout, stderr = run_with_mock_cwl_runner(args)
+    assert f"[1] opt-error1: Test with label{n}" in stdout
+    assert "opt-error2" not in stdout
+    assert "opt-error3" not in stdout


### PR DESCRIPTION
This request adds `--exclude-tags` option not to include tests with specified tags.
It is useful to test `command_line_tool` and `expression_tool` tags without `workflow` tag, for example.
