### PR TITLE
Validate actual file properties such as `checksum`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{36,37,38,39,310,311}-lint,
+  py{37,38,39,310,311}-lint,
   py{36,37,38,39,310,311}-unit,
   py{36,37,38,39,310,311}-bandit,
   py{37,38,39,310,311}-mypy,
@@ -58,7 +58,7 @@ commands =
   py{36,37,38,39,310,311}-unit: python -m pip install -U pip setuptools wheel
   py{36,37,38,39,310,311}-unit: python -m pytest --cov --cov-config={toxinidir}/.coveragerc --cov-append {posargs}
   py{36,37,38,39,310,311}-unit: coverage xml
-  py{36,37,38,39,310,311}-bandit: bandit --recursive cwltest --exclude tests/*
+  py{36,37,38,39,310,311}-bandit: bandit --recursive cwltest
   py{36,37,38,39,310,311}-lint: make flake8
   py{36,37,38,39,310,311}-lint: make format-check
   py{37,38,39,310,311}-mypy: make mypy


### PR DESCRIPTION
This request fixes #145 by checking that:
- the actual files and directories exist
- the checksum and size of actual file are same as expected values
