### PR TITLE
remove deprecated LEGACY_PATH support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PYSOURCES=$(wildcard ${MODULE}/**.py tests/*.py)
 DEVPKGS=-rdev-requirements.txt -rtest-requirements.txt -rmypy-requirements.txt
 DEBDEVPKGS=pep8 python-autopep8 pylint python-coverage pydocstyle sloccount \
 	   python-flake8 python-mock shellcheck
-VERSION=2.4.$(shell TZ=UTC git log --first-parent --max-count=1 \
+VERSION=2.5.$(shell TZ=UTC git log --first-parent --max-count=1 \
 	--format=format:%cd --date=format-local:%Y%m%d%H%M%S)
 
 ## all                    : default task (install in dev mode)

--- a/cwltest/argparser.py
+++ b/cwltest/argparser.py
@@ -1,4 +1,5 @@
 """Command line argument parsing for cwltest."""
+
 import argparse
 import sys
 from importlib.metadata import PackageNotFoundError, version

--- a/cwltest/plugin.py
+++ b/cwltest/plugin.py
@@ -1,4 +1,5 @@
 """Discovers CWL test files and converts them to pytest.Items."""
+
 import argparse
 import json
 import os
@@ -27,7 +28,6 @@ from cwltest import REQUIRED, UNSUPPORTED_FEATURE, logger, utils
 
 if TYPE_CHECKING:
     from _pytest._code.code import ExceptionInfo, _TracebackStyle
-    from _pytest.compat import LEGACY_PATH
     from _pytest.config import Config
     from _pytest.config import Config as PytestConfig
     from _pytest.config import PytestPluginManager
@@ -198,7 +198,7 @@ class CWLItem(pytest.Item):
 
     def reportinfo(self) -> Tuple[Union["os.PathLike[str]", str], Optional[int], str]:
         """Status report."""
-        return self.fspath, 0, "cwl test: %s" % self.name
+        return self.path, 0, "cwl test: %s" % self.name
 
 
 class CWLYamlFile(pytest.File):
@@ -342,7 +342,7 @@ def _doc_options() -> argparse.ArgumentParser:
 
 
 def pytest_collect_file(
-    file_path: Path, path: "LEGACY_PATH", parent: pytest.Collector
+    file_path: Path, parent: pytest.Collector
 ) -> Optional[pytest.Collector]:
     """Is this file for us."""
     if (

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -2,8 +2,8 @@
 Pytest plugin
 *************
 
-``cwltest`` can also be used as a Pytest plugin. The CWL test filename must
-end with ``.cwltest.yml`` or ``.cwltest.yaml``.
+``cwltest`` can also be used as a Pytest 7.x or 8.x plugin. The CWL test
+filename must end with ``.cwltest.yml`` or ``.cwltest.yaml``.
 
 In this case, the simple command::
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,4 +1,5 @@
 """Test prepare_test_command()"""
+
 import os
 
 from cwltest import utils

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,5 @@
 """Test functions."""
+
 import atexit
 import os
 import subprocess  # nosec


### PR DESCRIPTION
Pytest 8.1.0 removed support for that.

No need to change our supported Pytest range, the modern `pathlib.Path` support has been there since [Pytest 7.0](https://docs.pytest.org/en/stable/changelog.html#id282) https://github.com/pytest-dev/pytest/pull/8144
