### PR TITLE
Generate markdown reports to badgedir for each tag

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,5 @@ select = B,C,E,F,W,T4
 extend-ignore = E501,B905
 # when Python 3.10 is the minimum version, re-enable check B905 for zip + strict
 extend-select = B9
+per-file-ignores=
+    ./tests/test_badgedir.py:B950

--- a/cwltest/argparser.py
+++ b/cwltest/argparser.py
@@ -18,6 +18,9 @@ def arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--basedir", type=str, help="Basedir to use for tests", default="."
     )
+    parser.add_argument(
+        "--baseuri", type=str, help="Base URI to use links in the report", default=None
+    )
     parser.add_argument("-l", action="store_true", help="List tests then exit")
     parser.add_argument(
         "-n", type=str, default=None, help="Run specific tests, format is 1,3-6,9"

--- a/tests/test-data/badgedir.yaml
+++ b/tests/test-data/badgedir.yaml
@@ -1,0 +1,38 @@
+- output: {}
+  job: empty.yml
+  tool: return-0.cwl
+  id: success_w_job
+  doc: Successful test with a job file
+  tags: [ command_line_tool ]
+
+- output: {}
+  tool: return-0.cwl
+  id: success_wo_job
+  doc: Successful test without a job file
+  tags: [ command_line_tool ]
+
+- output: {}
+  job: empty.yml
+  tool: return-1.cwl
+  id: failure_w_job
+  doc: Failed test with a job file
+  tags: [ command_line_tool ]
+
+- output: {}
+  tool: return-1.cwl
+  id: failure_wo_job
+  doc: Failed test without a job file
+  tags: [ command_line_tool ]
+
+- output: {}
+  job: empty.yml
+  tool: return-unsupported.cwl
+  id: unsupported_w_job
+  doc: Unsupported test with a job file
+  tags: [ command_line_tool ]
+
+- output: {}
+  tool: return-unsupported.cwl
+  id: unsupported_wo_job
+  doc: Unsupported test without a job file
+  tags: [ command_line_tool ]

--- a/tests/test-data/conformance_test_v1.2.cwltest.yaml
+++ b/tests/test-data/conformance_test_v1.2.cwltest.yaml
@@ -13,3 +13,9 @@
   id: cl_optional_bindings_provided
   doc: Test command line with optional input (provided)
   tags: [ command_line_tool ]
+
+- tool: v1.0/null-expression2-tool.cwl
+  should_fail: true
+  id: expression_any_nodefaultany
+  doc: Test Any without defaults cannot be unspecified.
+  tags: [ required, inline_javascript, expression_tool ]

--- a/tests/test-data/mock_cwl_runner.py
+++ b/tests/test-data/mock_cwl_runner.py
@@ -15,7 +15,7 @@ TIMEOUT_TOOL = "timeout.cwl"
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("processfile")
-    parser.add_argument("jobfile")
+    parser.add_argument("jobfile", nargs='?', default=None)
     parser.add_argument("--version", action="version", version="%(prog)s 1.0")
     parser.add_argument("--outdir")
     parser.add_argument("--quiet", action="store_true")

--- a/tests/test-data/v1.0/null-expression2-tool.cwl
+++ b/tests/test-data/v1.0/null-expression2-tool.cwl
@@ -1,0 +1,14 @@
+#!/usr/bin/env cwl-runner
+
+class: ExpressionTool
+requirements:
+  - class: InlineJavascriptRequirement
+cwlVersion: v1.2
+
+inputs:
+  i1: Any
+
+outputs:
+  output: int
+
+expression: "$({'output': (inputs.i1 == 'the-default' ? 1 : 2)})"

--- a/tests/test_badgedir.py
+++ b/tests/test_badgedir.py
@@ -1,0 +1,98 @@
+import os
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import schema_salad.ref_resolver
+
+from .util import get_data, run_with_mock_cwl_runner
+
+
+def test_badgedir(tmp_path: Path) -> None:
+    badgedir = tmp_path / "badgedir"
+
+    args = [
+        "--test",
+        schema_salad.ref_resolver.file_uri(
+            get_data("tests/test-data/conformance_test_v1.2.cwltest.yaml")
+        ),
+        "--badgedir",
+        str(badgedir),
+    ]
+    cwd = os.getcwd()
+    try:
+        os.chdir(get_data("tests/test-data/"))
+        error_code, stdout, stderr = run_with_mock_cwl_runner(args)
+    finally:
+        os.chdir(cwd)
+
+    assert error_code == 1
+    required_json = badgedir / "required.json"
+    assert required_json.exists()
+    with open(required_json) as file:
+        obj = json.load(file)
+        assert obj.get("subject", "") == "required"
+        assert obj.get("status", "") == "0%"
+        assert obj.get("color", "") == "red"
+
+    required_md = badgedir / "required.md"
+    assert required_md.exists()
+    with open(required_md) as file:
+        s = file.read()
+        assert "file://" in s
+        assert "tests/test-data/conformance_test_v1.2.cwltest.yaml" in s
+        assert "v1.0/cat-job.json" in s
+        assert "v1.0/cat1-testcli.cwl" in s
+
+    clt = badgedir / "command_line_tool.json"
+    assert clt.exists()
+    with open(clt) as file:
+        obj = json.load(file)
+        assert obj.get("subject", "") == "command_line_tool"
+        assert obj.get("status", "") == "0%"
+        assert obj.get("color", "") == "yellow"
+    assert (badgedir / "command_line_tool.md").exists()
+
+
+def test_badgedir_report_with_baseuri(tmp_path: Path) -> None:
+    badgedir = tmp_path / "badgedir"
+
+    baseuri = "https://example.com/specified/uri"
+
+    args = [
+        "--test",
+        schema_salad.ref_resolver.file_uri(get_data("tests/test-data/badgedir.yaml")),
+        "--badgedir",
+        str(badgedir),
+        "--baseuri",
+        baseuri,
+    ]
+    cwd = os.getcwd()
+    try:
+        os.chdir(get_data("tests/test-data/"))
+        error_code, stdout, stderr = run_with_mock_cwl_runner(args)
+    finally:
+        os.chdir(cwd)
+
+    clt_md = badgedir / "command_line_tool.md"
+    assert clt_md.exists()
+    with open(clt_md) as file:
+        contents = file.read()
+        assert contents == markdown_report_with(baseuri)
+
+
+def markdown_report_with(baseuri: str) -> str:
+    return dedent(
+        f"""
+        # `command_line_tool` tests
+        ## List of passed tests
+        - [success_w_job]({baseuri}/badgedir.yaml#L0) ([tool]({baseuri}/return-0.cwl), [job]({baseuri}/empty.yml))
+        - [success_wo_job]({baseuri}/badgedir.yaml#L7) ([tool]({baseuri}/return-0.cwl))
+        ## List of failed tests
+        - [failure_w_job]({baseuri}/badgedir.yaml#L13) ([tool]({baseuri}/return-1.cwl), [job]({baseuri}/empty.yml))
+        - [failure_wo_job]({baseuri}/badgedir.yaml#L20) ([tool]({baseuri}/return-1.cwl))
+        ## List of unsupported tests
+        - [unsupported_w_job]({baseuri}/badgedir.yaml#L26) ([tool]({baseuri}/return-unsupported.cwl), [job]({baseuri}/empty.yml))
+        - [unsupported_wo_job]({baseuri}/badgedir.yaml#L33) ([tool]({baseuri}/return-unsupported.cwl))
+        """
+    )[1:]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,6 +13,7 @@ def _load_v1_0_dir(path: Path) -> None:
     inner_dir = os.path.join(path.parent, "v1.0")
     os.mkdir(inner_dir)
     shutil.copy(get_data("tests/test-data/v1.0/cat1-testcli.cwl"), inner_dir)
+    shutil.copy(get_data("tests/test-data/v1.0/null-expression2-tool.cwl"), inner_dir)
     shutil.copy(get_data("tests/test-data/v1.0/cat-job.json"), inner_dir)
     shutil.copy(get_data("tests/test-data/v1.0/cat-n-job.json"), inner_dir)
     shutil.copy(get_data("tests/test-data/v1.0/hello.txt"), inner_dir)
@@ -104,7 +105,7 @@ def test_no_label(pytester: "Pytester") -> None:
     result = pytester.runpytest(
         "-k", "conformance_test_v1.2.cwltest.yaml", "--cwl-tags", "required"
     )
-    result.assert_outcomes(passed=1, skipped=1)
+    result.assert_outcomes(passed=2, skipped=1)
 
 
 def test_cwltool_hook(pytester: "Pytester") -> None:


### PR DESCRIPTION
This request is to generate an extra report in addition to generate a badge file for each tag.

# Motivation
cwltest has a feature to generate conformance badges to show the percentage of passed tests for each tag.
It is very useful for users to check appropriate engines for their needs as well as for developers to improve the conformant of their engines.

Developers of workflow engines can check the list of passed, failed and unsupported tests by checking the resulted JUnit XML. Here is an example:
- https://github.com/tom-tan/shaft/actions/runs/8669927236/job/23777395814

On the other hand, it is hard for users to check the lists of passed, failed and unsupported tests.
They can see the lists by checking the result page of Github Actions for the engine but it is not persistent.
Of course, it is possible for developers of workflow engines to provide lists as [REANA does](https://docs.reana.io/running-workflows/supported-systems/cwl/#cwl-v12-specification-conformance-results) but it would be nice if cwltest provides a handy way to provide lists for investigation.

# Implementation
By merging this request, cwltest generates a markdown such as `command_line_tool.md` in addition to `command_line_tool.json` to the badgedir as show below. I put a complete example to [Gist](https://gist.github.com/tom-tan/a896882f753d2631cb46229399cb727e).
To make links, I added `--baseuri` option to cwltest.

---
# `command_line_tool` tests
## List of passed tests
- [stderr_redirect](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//conformance_test_v1.0.yaml#L97) ([tool](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/stderr.cwl), [job](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/empty.json))
- [stderr_redirect_shortcut](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//conformance_test_v1.0.yaml#L109) ([tool](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/stderr-shortcut.cwl), [job](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/empty.json))
- [stderr_redirect_mediumcut](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//conformance_test_v1.0.yaml#L121) ([tool](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/stderr-mediumcut.cwl), [job](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/empty.json))
- [stdinout_redirect](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//conformance_test_v1.0.yaml#L201) ([tool](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/cat-tool.cwl), [job](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/cat-job.json))
## List of failed tests
- [cl_basic_generation](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//conformance_test_v1.0.yaml#L0) ([tool](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/bwa-mem-tool.cwl), [job](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/bwa-mem-job.json))
- [nested_prefixes_arrays](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//conformance_test_v1.0.yaml#L11) ([tool](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/binding-test.cwl), [job](https://github.com/common-workflow-language/common-workflow-language/tree/main/v1.0//v1.0/bwa-mem-job.json))
...
---
Each entry consists of:
- an `id` field and a link to the corresponding test entry,
- a link to the tool or workflow description, and
- a link to the job description if available.

It makes easier for users to choose more appropriate workflow engines for their needs.

Notes:
- The tests still works without `--baseuri` option. In that case, cwltest generates markdown files with links to the local files.
- Another way to achieve this is to introduce the `$base` field to the file specified by `--test`. It is possible because a given test entry file is parsed by schema_salad library with the [schema for cwltest](https://github.com/common-workflow-language/cwltest/blob/main/cwltest/cwltest-schema.yml). I did not use this policy because:
  - The schema salad library does not provide a way to obtain a base URI of a given schema.
  - It may cause network access to the base URI even if it is used only to generate links in the markdown files.
