### PR TITLE
Replace `{distdir}` with `dist`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,8 +83,8 @@ skip_install = true
 [testenv:py312-lintreadme]
 description = Lint the README.rst->.md conversion
 commands =
-  python -m build --outdir {distdir}
-  twine check {distdir}/*
+  python -m build --outdir dist
+  twine check dist/*
 deps =
     twine
     build


### PR DESCRIPTION
This request is to fix #210.

As I mentioned in #210, the source of problem is that tox removed the `distdir` variable in 4.0.

An official document [suggests](https://tox.wiki/en/4.15.1/upgrading.html#removed-tox-ini-keys) to use `$TOX_PACKAGE` instead of `{distdir}`.
On the other hand, as reported in tox-dev/tox#2706, just replacing `{distdir}` with `$TOX_PACKAGE` does not work as we expected.

This request just replaces `{distdir}` with `dist`.
It is simple enough and I hope it works as we expected.
