### PR TITLE
Remove redundant code

### DIFF
--- a/cwltest/utils.py
+++ b/cwltest/utils.py
@@ -343,11 +343,6 @@ def parse_results(
             for t in tags:
                 nfailures[t].append(test_report)
             test_case.add_failure_info(output=test_result.message)
-        elif return_code == UNSUPPORTED_FEATURE and category == REQUIRED:
-            failures += 1
-            for t in tags:
-                nfailures[t].append(test_report)
-            test_case.add_failure_info(output=test_result.message)
         elif category != REQUIRED and return_code == UNSUPPORTED_FEATURE:
             unsupported += 1
             for t in tags:


### PR DESCRIPTION
As mentioned in [#209](https://github.com/common-workflow-language/cwltest/pull/209#issuecomment-2185656207), the removed code in this PR is never executed.
