### PR TITLE
Always use lightweight tags for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ release:
 		python -m build testenv2/src/${PACKAGE} && \
 		pip install twine && \
 		twine upload testenv2/src/${PACKAGE}/dist/* && \
-		git tag ${VERSION} && git push --tags
+		git tag --no-sign ${VERSION} && git push --tags
 
 flake8: FORCE
 	flake8 $(PYSOURCES)


### PR DESCRIPTION
It is to fix the issue reported in [#214](https://github.com/common-workflow-language/cwltest/pull/214#issuecomment-2217078189).

When a maintainer uses the following .gitconfig, `make release` forces to make an annotated tag rather than a lightweight tag.
When a maintainer's .gitconfig does not contain this configuration, `make release` makes a lightweight tag.

```.gitconfig
[tag]
        gpgsign = true
```

This PR is to unify to use lightweight tags because existing releases already use them.

Note: @mr-c and I have no strong opinions for annotated and lightweight tags. This request is just to unify the release process.