### PR TITLE
Fix issue216: take care of the case with `job` field with null value

### DIFF
--- a/cwltest/plugin.py
+++ b/cwltest/plugin.py
@@ -67,7 +67,7 @@ def _run_test_hook_or_plain(
     start_time = time.time()
     reltool = os.path.relpath(test["tool"], start=config.test_basedir)
     tooluri = urljoin(config.test_baseuri, reltool)
-    if "job" in test:
+    if test.get("job", None):
         reljob = os.path.relpath(test["job"], start=config.test_basedir)
         joburi = urljoin(config.test_baseuri, reljob)
     else:

--- a/cwltest/utils.py
+++ b/cwltest/utils.py
@@ -440,7 +440,7 @@ def run_test_plain(
 
     reltool = os.path.relpath(test["tool"], start=config.test_basedir)
     tooluri = urljoin(config.test_baseuri, reltool)
-    if "job" in test:
+    if test.get("job", None):
         reljob = os.path.relpath(test["job"], start=config.test_basedir)
         joburi = urljoin(config.test_baseuri, reljob)
     else:

--- a/tests/test-data/badgedir.yaml
+++ b/tests/test-data/badgedir.yaml
@@ -32,6 +32,7 @@
   tags: [ command_line_tool ]
 
 - output: {}
+  job: null
   tool: return-unsupported.cwl
   id: unsupported_wo_job
   doc: Unsupported test without a job file


### PR DESCRIPTION
This request is to fix #216.

It was introduced by #209 due to missing the case with `job` field with explicit null value.
This request fixes it by adding the case with `job: null` in addition to the case of missing `job` field.