### PR TITLE
Replace ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,7 +15,7 @@ jobs:
   tox:
     name: CI tests via Tox
 
-    runs-on: ubuntu-20.04  # 22.04 doesn't support Python 3.6
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/