### PR TITLE
Fix badge generation for xdist

### DIFF
--- a/cwltest/plugin.py
+++ b/cwltest/plugin.py
@@ -17,11 +17,7 @@ from cwltest import REQUIRED, UNSUPPORTED_FEATURE, logger, utils
 from cwltest.compare import CompareFail, compare
 
 if TYPE_CHECKING:
-    from _pytest._code.code import ExceptionInfo, TracebackStyle
-    from _pytest.config import Config
-    from _pytest.config import Config as PytestConfig
-    from _pytest.config import PytestPluginManager
-    from _pytest.config.argparsing import Parser as PytestParser
+    from _pytest._code.code import TracebackStyle
     from _pytest.nodes import Node
     from pluggy import HookCaller
 
@@ -36,7 +32,7 @@ class TestRunner(Protocol):
         ...
 
 
-def _get_comma_separated_option(config: "Config", name: str) -> list[str]:
+def _get_comma_separated_option(config: pytest.Config, name: str) -> list[str]:
     options = config.getoption(name)
     if options is None:
         return []
@@ -195,7 +191,7 @@ class CWLItem(pytest.Item):
 
     def repr_failure(
         self,
-        excinfo: "ExceptionInfo[BaseException]",
+        excinfo: pytest.ExceptionInfo[BaseException],
         style: Optional["TracebackStyle"] = None,
     ) -> str:
         """
@@ -359,7 +355,7 @@ __OPTIONS: list[tuple[str, dict[str, Any]]] = [
 ]
 
 
-def pytest_addoption(parser: "PytestParser") -> None:
+def pytest_addoption(parser: pytest.Parser) -> None:
     """Add our options to the pytest command line."""
     for entry in __OPTIONS:
         parser.addoption(entry[0], **entry[1])
@@ -387,7 +383,7 @@ def pytest_collect_file(
     return None
 
 
-def pytest_configure(config: "PytestConfig") -> None:
+def pytest_configure(config: pytest.Config) -> None:
     """Store the raw tests and the test results."""
     cwl_results: list[tuple[dict[str, Any], utils.TestResult]] = []
     config.cwl_results = cwl_results  # type: ignore[attr-defined]
@@ -417,7 +413,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
         utils.generate_badges(cwl_badgedir, ntotal, npassed, nfailures, nunsupported)
 
 
-def pytest_addhooks(pluginmanager: "PytestPluginManager") -> None:
+def pytest_addhooks(pluginmanager: pytest.PytestPluginManager) -> None:
     """Register our cwl hooks."""
     from cwltest import hooks
 

--- a/cwltest/utils.py
+++ b/cwltest/utils.py
@@ -69,7 +69,12 @@ class CWLTestReport:
     """Encapsulate relevant test result data for a markdown report."""
 
     def __init__(
-        self, id: str, category: list[str], entry: str, tool: str, job: Optional[str]
+        self,
+        id: Union[int, str],
+        category: list[str],
+        entry: str,
+        tool: str,
+        job: Optional[str],
     ) -> None:
         """Initialize a CWLTestReport object."""
         self.id = id
@@ -199,10 +204,9 @@ def generate_badges(
 
         with open(f"{badgedir}/{t}.md", "w") as out:
             print(f"# `{t}` tests", file=out)
-
             print("## List of passed tests", file=out)
             for e in npassed[t]:
-                base = f"[{shortname(e.id)}]({e.entry})"
+                base = f"[{shortname(str(e.id))}]({e.entry})"
                 tool = f"[tool]({e.tool})"
                 if e.job:
                     arr = [tool, f"[job]({e.job})"]
@@ -213,7 +217,7 @@ def generate_badges(
 
             print("## List of failed tests", file=out)
             for e in nfailures[t]:
-                base = f"[{shortname(e.id)}]({e.entry})"
+                base = f"[{shortname(str(e.id))}]({e.entry})"
                 tool = f"[tool]({e.tool})"
                 if e.job:
                     arr = [tool, f"[job]({e.job})"]
@@ -224,7 +228,7 @@ def generate_badges(
 
             print("## List of unsupported tests", file=out)
             for e in nunsupported[t]:
-                base = f"[{shortname(e.id)}]({e.entry})"
+                base = f"[{shortname(str(e.id))}]({e.entry})"
                 tool = f"[tool]({e.tool})"
                 if e.job:
                     arr = [tool, f"[job]({e.job})"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,12 +1,10 @@
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+import pytest
 
 from .util import get_data
-
-if TYPE_CHECKING:
-    from _pytest.pytester import Pytester
 
 
 def _load_v1_0_dir(path: Path) -> None:
@@ -20,7 +18,7 @@ def _load_v1_0_dir(path: Path) -> None:
     shutil.copy(get_data("tests/test-data/v1.0/args.py"), inner_dir)
 
 
-def test_include(pytester: "Pytester") -> None:
+def test_include(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin using cwltool as cwl-runner."""
     path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
     shutil.copy(
@@ -36,7 +34,7 @@ def test_include(pytester: "Pytester") -> None:
     result.assert_outcomes(passed=1, skipped=1)
 
 
-def test_exclude(pytester: "Pytester") -> None:
+def test_exclude(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin using cwltool as cwl-runner."""
     path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
     shutil.copy(
@@ -52,7 +50,7 @@ def test_exclude(pytester: "Pytester") -> None:
     result.assert_outcomes(passed=0, skipped=2)
 
 
-def test_tags(pytester: "Pytester") -> None:
+def test_tags(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin using cwltool as cwl-runner."""
     path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
     shutil.copy(
@@ -65,7 +63,7 @@ def test_tags(pytester: "Pytester") -> None:
     result.assert_outcomes(passed=1, skipped=1)
 
 
-def test_exclude_tags(pytester: "Pytester") -> None:
+def test_exclude_tags(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin using cwltool as cwl-runner."""
     path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
     shutil.copy(
@@ -81,7 +79,7 @@ def test_exclude_tags(pytester: "Pytester") -> None:
     result.assert_outcomes(skipped=2)
 
 
-def test_badgedir(pytester: "Pytester") -> None:
+def test_badgedir(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin creates the badges directory."""
     path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
     shutil.copy(
@@ -95,7 +93,7 @@ def test_badgedir(pytester: "Pytester") -> None:
     assert os.path.exists("cwl-badges")
 
 
-def test_no_label(pytester: "Pytester") -> None:
+def test_no_label(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin correctly extracts test names from the id field when label is missing."""
     path = pytester.copy_example("conformance_test_v1.2.cwltest.yaml")
     shutil.copy(
@@ -108,7 +106,7 @@ def test_no_label(pytester: "Pytester") -> None:
     result.assert_outcomes(passed=2, skipped=1)
 
 
-def test_cwltool_hook(pytester: "Pytester") -> None:
+def test_cwltool_hook(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin using cwltool as cwl-runner."""
     path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
     shutil.copy(
@@ -119,7 +117,7 @@ def test_cwltool_hook(pytester: "Pytester") -> None:
     result.assert_outcomes(passed=2)
 
 
-def test_no_hook(pytester: "Pytester") -> None:
+def test_no_hook(pytester: pytest.Pytester) -> None:
     """Test the pytest plugin using the default cwl-runner."""
     path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
     _load_v1_0_dir(path)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -86,11 +86,16 @@ def test_badgedir(pytester: pytest.Pytester) -> None:
         get_data("tests/test-data/cwltool-conftest.py"), path.parent / "conftest.py"
     )
     _load_v1_0_dir(path)
-    assert not os.path.exists("cwl-badges")
+    badge_path = path.parent / "cwl-badges"
+    assert not badge_path.exists()
     pytester.runpytest(
-        "-k", "conformance_test_v1.0.cwltest.yml", "--cwl-badgedir", "cwl-badges"
+        "-k", "conformance_test_v1.0.cwltest.yml", "--cwl-badgedir", str(badge_path)
     )
-    assert os.path.exists("cwl-badges")
+    assert badge_path.exists()
+    assert (badge_path / "command_line_tool.json").exists()
+    assert (badge_path / "command_line_tool.md").exists()
+    assert (badge_path / "required.json").exists()
+    assert (badge_path / "required.md").exists()
 
 
 def test_no_label(pytester: pytest.Pytester) -> None:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -88,9 +88,35 @@ def test_badgedir(pytester: pytest.Pytester) -> None:
     _load_v1_0_dir(path)
     badge_path = path.parent / "cwl-badges"
     assert not badge_path.exists()
-    pytester.runpytest(
+    result = pytester.runpytest_inprocess(
         "-k", "conformance_test_v1.0.cwltest.yml", "--cwl-badgedir", str(badge_path)
     )
+    result.assert_outcomes(passed=2)
+    assert badge_path.exists()
+    assert (badge_path / "command_line_tool.json").exists()
+    assert (badge_path / "command_line_tool.md").exists()
+    assert (badge_path / "required.json").exists()
+    assert (badge_path / "required.md").exists()
+
+
+def test_badgedir_xdist(pytester: pytest.Pytester) -> None:
+    """Test the pytest plugin creates the badges directory even with xdist."""
+    path = pytester.copy_example("conformance_test_v1.0.cwltest.yml")
+    shutil.copy(
+        get_data("tests/test-data/cwltool-conftest.py"), path.parent / "conftest.py"
+    )
+    _load_v1_0_dir(path)
+    badge_path = path.parent / "cwl-badges"
+    assert not badge_path.exists()
+    result = pytester.runpytest_inprocess(
+        "-n",
+        "2",
+        "-k",
+        "conformance_test_v1.0.cwltest.yml",
+        "--cwl-badgedir",
+        str(badge_path),
+    )
+    result.assert_outcomes(passed=2)
     assert badge_path.exists()
     assert (badge_path / "command_line_tool.json").exists()
     assert (badge_path / "command_line_tool.md").exists()


### PR DESCRIPTION
- sort inputs
- simplify some inputs
- fix badge generation for test with int IDs.
- fix badge generation with pytest-xdist, fixes #239 
