### PR TITLE
Support integer ids from pytest plugin

### DIFF
--- a/src/cwltest/plugin.py
+++ b/src/cwltest/plugin.py
@@ -257,7 +257,7 @@ class CWLYamlFile(pytest.File):
             if "label" in entry:
                 name = entry["label"]
             elif "id" in entry:
-                name = utils.shortname(entry["id"])
+                name = utils.shortname(str(entry["id"]))
             else:
                 name = entry.get("doc", "")
             item = CWLItem.from_parent(self, name=name, spec=entry)

--- a/tests/test-data/integer-id.cwltest.yml
+++ b/tests/test-data/integer-id.cwltest.yml
@@ -1,0 +1,7 @@
+- output:
+    args: [cat, hello.txt]
+  job: v1.0/cat-job.json
+  tool: v1.0/cat1-testcli.cwl
+  id: 4
+  doc: Test command line with optional input (missing)
+  tags: [ required, command_line_tool ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -154,3 +154,11 @@ def test_no_hook(pytester: pytest.Pytester) -> None:
     _load_v1_0_dir(path)
     result = pytester.runpytest("-k", "conformance_test_v1.0.cwltest.yml")
     result.assert_outcomes(passed=2)
+
+
+def test_integer_id(pytester: pytest.Pytester) -> None:
+    """Test that the pytest plugin supports integer ids."""
+    path = pytester.copy_example("integer-id.cwltest.yml")
+    _load_v1_0_dir(path)
+    result = pytester.runpytest("-k", "integer-id.cwltest.yml")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Before this commit, tests were failing if a test had a numerical id and provided no label. This commit fixes this behaviour by explicitly casting the `entry['id']` value to string.