### PR TITLE
327: Fix failure to load custom fsaccess entry point on Python 3.12+.

### DIFF
--- a/src/cwltest/utils.py
+++ b/src/cwltest/utils.py
@@ -664,9 +664,7 @@ def load_optional_fsaccess_plugin() -> None:
     use that to get a filesystem access object that will be used for
     checking test output.
     """
-    fsaccess_eps: tuple[EntryPoint] = tuple(
-        entry_points(group="cwltest.fsaccess")
-    )
+    fsaccess_eps: tuple[EntryPoint, ...] = tuple(entry_points(group="cwltest.fsaccess"))
 
     if len(fsaccess_eps) == 0:
         return

--- a/src/cwltest/utils.py
+++ b/src/cwltest/utils.py
@@ -664,17 +664,9 @@ def load_optional_fsaccess_plugin() -> None:
     use that to get a filesystem access object that will be used for
     checking test output.
     """
-    fsaccess_eps: list[EntryPoint]
-
-    try:
-        # The interface to importlib.metadata.entry_points() changed
-        # several times between Python 3.10 and 3.13; the code below
-        # actually works fine on all of them but there's no single
-        # mypy annotation that works across of them.  Explicitly cast
-        # it to a consistent type to make mypy shut up.
-        fsaccess_eps = cast(list[EntryPoint], entry_points()["cwltest.fsaccess"])  # type: ignore [redundant-cast, unused-ignore]
-    except KeyError:
-        return
+    fsaccess_eps: tuple[EntryPoint] = tuple(
+        entry_points(group="cwltest.fsaccess")
+    )
 
     if len(fsaccess_eps) == 0:
         return

--- a/src/cwltest/utils.py
+++ b/src/cwltest/utils.py
@@ -670,7 +670,7 @@ def load_optional_fsaccess_plugin() -> None:
         return
 
     if len(fsaccess_eps) > 1:
-        logger.warn(
+        logger.warning(
             "More than one cwltest.fsaccess entry point found, selected %s",
             fsaccess_eps[0],
         )

--- a/tests/test_load_custom_fsaccess.py
+++ b/tests/test_load_custom_fsaccess.py
@@ -53,4 +53,4 @@ def test_load_fsaccess(n: int) -> None:
 
         import cwltest.compare
 
-        assert cwltest.compare.fs_access == sentinel.custom_fs_access
+        assert cwltest.compare.fs_access is sentinel.custom_fs_access

--- a/tests/test_load_custom_fsaccess.py
+++ b/tests/test_load_custom_fsaccess.py
@@ -1,0 +1,56 @@
+from typing import Callable
+from unittest.mock import MagicMock, patch, sentinel
+
+import pytest
+
+from cwltest.utils import load_optional_fsaccess_plugin
+
+
+def get_mock_entry_point(set_sentinel: bool = False) -> MagicMock:
+    """Returns a mock object whose `load()` method may optionally return
+    a sentinel value.
+    """
+    m: MagicMock = MagicMock()
+    if set_sentinel:
+        m.load.return_value.return_value = sentinel.custom_fs_access
+    return m
+
+
+def mock_entry_points(n: int = 1) -> Callable[..., MagicMock]:
+    """Returns a plain function that emulates
+    `importlib.metadata.entry_points`.
+    """
+    mock_ep_data: tuple[MagicMock, ...] = tuple(
+        get_mock_entry_point(i == 0) for i in range(n)
+    )
+    mock_eps: MagicMock = MagicMock()
+    mock_eps.__iter__ = lambda self: iter(mock_ep_data)
+    mock_eps.__len__.return_value = n
+    mock_eps.__getitem__.side_effect = KeyError
+
+    def entry_points(**kwargs: str) -> MagicMock:
+        return mock_eps
+
+    return entry_points
+
+
+def test_default_fsaccess_fallback() -> None:
+    with patch("cwltest.utils.entry_points", mock_entry_points(0)):
+        load_optional_fsaccess_plugin()
+
+        from cwltest import compare, stdfsaccess
+
+        assert compare.fs_access
+        assert isinstance(compare.fs_access, stdfsaccess.StdFsAccess)
+
+
+@pytest.mark.parametrize("n", (1, 2))
+def test_load_fsaccess(n: int) -> None:
+    with patch("cwltest.utils.entry_points", mock_entry_points(n)) as mfcn:
+        load_optional_fsaccess_plugin()
+        ep = tuple(mfcn())[0]
+        ep.load.assert_called_once_with()
+
+        import cwltest.compare
+
+        assert cwltest.compare.fs_access == sentinel.custom_fs_access


### PR DESCRIPTION
Starting from Python 3.12, the return value of `importlib.metadata.entry_points()` can no longer be indexed by a group string; see "Compatibility Notes" under https://docs.python.org/3.12/library/importlib.metadata.html#entry-points.

To fix, call `entry_points(group="cwltest.fsaccess")` instead.

Closes #327.